### PR TITLE
Use AbstractFloat types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
   - osx
   - linux
 julia:
-  - 0.3
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.5
 Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+environment:
+  matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"SkyCoords\"); Pkg.build(\"SkyCoords\")"
+
+test_script:
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"SkyCoords\")"

--- a/bench/bench.jl
+++ b/bench/bench.jl
@@ -8,19 +8,19 @@ for n in [1, 10, 100, 1000, 10_000, 100_000, 1_000_000]
     println("$n coordinates: ")
     if n == 1
         c = ICRSCoords(2pi*rand(), pi*(rand() - 0.5))
-        t1 = @timeit convert(GalCoords{Float64}, c)
+        t1 = @timeit convert(GalCoords, c)
         println(io, "$n,galactic,$t1")
-        t2 = @timeit convert(FK5Coords{Float64,2000}, c)
+        t2 = @timeit convert(FK5Coords{2000}, c)
         println(io, "$n,fk5j2000,$t2")
-        t3 = @timeit convert(FK5Coords{Float64,1975}, c)
+        t3 = @timeit convert(FK5Coords{1975}, c)
         println(io, "$n,fk5j1975,$t3")
     else
         c = [ICRSCoords(2pi*rand(), pi*(rand() - 0.5)) for i=1:n]
         t1 = @timeit convert(Vector{GalCoords{Float64}}, c)
         println(io, "$n,galactic,$t1")
-        t2 = @timeit convert(Vector{FK5Coords{Float64,2000}}, c)
+        t2 = @timeit convert(Vector{FK5Coords{2000, Float64}}, c)
         println(io, "$n,fk5j2000,$t2")
-        t3 = @timeit convert(Vector{FK5Coords{Float64,1975}}, c)
+        t3 = @timeit convert(Vector{FK5Coords{1975, Float64}}, c)
         println(io, "$n,fk5j1975,$t3")
     end
 end

--- a/bench/bench.jl
+++ b/bench/bench.jl
@@ -8,19 +8,19 @@ for n in [1, 10, 100, 1000, 10_000, 100_000, 1_000_000]
     println("$n coordinates: ")
     if n == 1
         c = ICRSCoords(2pi*rand(), pi*(rand() - 0.5))
-        t1 = @timeit convert(GalCoords, c)
+        t1 = @timeit convert(GalCoords{Float64}, c)
         println(io, "$n,galactic,$t1")
-        t2 = @timeit convert(FK5Coords{2000}, c)
+        t2 = @timeit convert(FK5Coords{Float64,2000}, c)
         println(io, "$n,fk5j2000,$t2")
-        t3 = @timeit convert(FK5Coords{1975}, c)
+        t3 = @timeit convert(FK5Coords{Float64,1975}, c)
         println(io, "$n,fk5j1975,$t3")
     else
         c = [ICRSCoords(2pi*rand(), pi*(rand() - 0.5)) for i=1:n]
-        t1 = @timeit convert(Vector{GalCoords}, c)
+        t1 = @timeit convert(Vector{GalCoords{Float64}}, c)
         println(io, "$n,galactic,$t1")
-        t2 = @timeit convert(Vector{FK5Coords{2000}}, c)
+        t2 = @timeit convert(Vector{FK5Coords{Float64,2000}}, c)
         println(io, "$n,fk5j2000,$t2")
-        t3 = @timeit convert(Vector{FK5Coords{1975}}, c)
+        t3 = @timeit convert(Vector{FK5Coords{Float64,1975}}, c)
         println(io, "$n,fk5j1975,$t3")
     end
 end

--- a/src/SkyCoords.jl
+++ b/src/SkyCoords.jl
@@ -30,13 +30,19 @@ GalCoords{T<:AbstractFloat}(l::T, b::T) = GalCoords{T}(l, b)
 GalCoords(l::Real, b::Real) = GalCoords(promote(float(l), float(b))...)
 
 # FK5 is parameterized by equinox (e)
-immutable FK5Coords{T<:AbstractFloat,e} <: AbstractSkyCoords
+immutable FK5Coords{e, T<:AbstractFloat} <: AbstractSkyCoords
     ra::T
     dec::T
     FK5Coords(ra, dec) = new(mod(ra, 2pi), dec)
 end
-FK5Coords{T<:AbstractFloat}(ra::T, dec::T) = FK5Coords{T}(ra, dec)
-FK5Coords(ra::Real, dec::Real) = FK5Coords(promote(float(ra), float(dec))...)
+(::Type{FK5Coords{e}}){e,T}(ra::T, dec::T) = FK5Coords{e, T}(ra, dec)
+
+# We'd like to define this promotion constructor, but in Julia 0.5,
+# the typing algorithm can't figure out that the previous method is
+# more specific, so this promotion constructor calls itself, resulting in
+# stack overflow.
+#(::Type{FK5Coords{e}}){e}(ra::Real, dec::Real) =
+#    FK5Coords{e}(promote(float(ra), float(dec))...)
 
 # -----------------------------------------------------------------------------
 # Helper functions: Immutable array operations
@@ -56,6 +62,12 @@ immutable Matrix33{T<:AbstractFloat}
     a32::T
     a33::T
 end
+
+(::Type{Matrix33{T}}){T}(m::Matrix33{T}) = m
+(::Type{Matrix33{T}}){T}(m::Matrix33) =
+    Matrix33(T(m.a11), T(m.a12), T(m.a13),
+             T(m.a21), T(m.a22), T(m.a23),
+             T(m.a31), T(m.a32), T(m.a33))
 
 immutable Vector3{T<:AbstractFloat}
     x::T
@@ -84,6 +96,7 @@ function *(m::Matrix33, v::Vector3)
             m.a21 * v.x + m.a22 * v.y + m.a23 * v.z,
             m.a31 * v.x + m.a32 * v.y + m.a33 * v.z)
 end
+
 
 # -----------------------------------------------------------------------------
 # Helper functions: Create rotation matrix about a given axis (x, y, z)
@@ -185,27 +198,51 @@ end
 # Abstract away specific field names (ra, dec vs l, b)
 coords2cart(c::ICRSCoords) = coords2cart(c.ra, c.dec)
 coords2cart(c::GalCoords) = coords2cart(c.l, c.b)
-coords2cart{e,T}(c::FK5Coords{T,e}) = coords2cart(c.ra, c.dec)
+coords2cart(c::FK5Coords) = coords2cart(c.ra, c.dec)
 
 # Rotation matrix between coordinate systems: `rotmat(to, from)`
-rotmat{T1<:AbstractFloat,T2<:AbstractFloat}(::Type{GalCoords{T1}},
-                                            ::Type{ICRSCoords{T2}}) = ICRS_TO_GAL
-rotmat{T1,T2}(::Type{ICRSCoords{T1}}, ::Type{GalCoords{T2}}) = GAL_TO_ICRS
-rotmat{e,T1,T2}(::Type{FK5Coords{T1,e}}, ::Type{ICRSCoords{T2}}) =
-    precess_from_j2000(e) * ICRS_TO_FK5J2000
-rotmat{e,T1,T2}(::Type{FK5Coords{T1,e}}, ::Type{GalCoords{T2}}) =
-    precess_from_j2000(e) * GAL_TO_FK5J2000
-rotmat{e,T1,T2}(::Type{ICRSCoords{T1}}, ::Type{FK5Coords{T2,e}}) =
-    FK5J2000_TO_ICRS * precess_from_j2000(e)'
-rotmat{e,T1,T2}(::Type{GalCoords{T1}}, ::Type{FK5Coords{T2,e}}) =
-    FK5J2000_TO_GAL * precess_from_j2000(e)'
-rotmat{e1,T1,e2,T2}(::Type{FK5Coords{T1,e1}}, ::Type{FK5Coords{T2,e2}}) =
+# Note that all of these return Matrix33{Float64}, regardless of
+# element type of input coordinates.
+rotmat{T1<:GalCoords, T2<:ICRSCoords}(::Type{T1}, ::Type{T2}) = ICRS_TO_GAL
+rotmat{T1<:ICRSCoords, T2<:GalCoords}(::Type{T1}, ::Type{T2}) = GAL_TO_ICRS
+
+# Define both these so that `convert(FK5Coords{e}, ...)` and
+# `convert(FK5Coords{e,T}, ...)` both work. Similar with other
+# FK5Coords rotmat methods below.
+rotmat{e1, T2<:ICRSCoords}(::Type{FK5Coords{e1}}, ::Type{T2}) =
+    precess_from_j2000(e1) * ICRS_TO_FK5J2000
+rotmat{e1, T1, T2<:ICRSCoords}(::Type{FK5Coords{e1,T1}}, ::Type{T2}) =
+    precess_from_j2000(e1) * ICRS_TO_FK5J2000
+
+rotmat{e1, T2<:GalCoords}(::Type{FK5Coords{e1}}, ::Type{T2}) =
+    precess_from_j2000(e1) * GAL_TO_FK5J2000
+rotmat{e1, T1, T2<:GalCoords}(::Type{FK5Coords{e1,T1}}, ::Type{T2}) =
+    precess_from_j2000(e1) * GAL_TO_FK5J2000
+
+rotmat{T1<:ICRSCoords, e2, T2}(::Type{T1}, ::Type{FK5Coords{e2,T2}}) =
+    FK5J2000_TO_ICRS * precess_from_j2000(e2)'
+
+rotmat{T1<:GalCoords, e2, T2}(::Type{T1}, ::Type{FK5Coords{e2,T2}}) =
+    FK5J2000_TO_GAL * precess_from_j2000(e2)'
+
+rotmat{e1, e2, T2}(::Type{FK5Coords{e1}}, ::Type{FK5Coords{e2,T2}}) =
     precess_from_j2000(e1) * precess_from_j2000(e2)'
+rotmat{e1, T1, e2, T2}(::Type{FK5Coords{e1,T1}}, ::Type{FK5Coords{e2,T2}}) =
+    precess_from_j2000(e1) * precess_from_j2000(e2)'
+
+# get floating point type in coordinates
+_eltype{e,T}(::FK5Coords{e,T}) = T
+_eltype{T}(::GalCoords{T}) = T
+_eltype{T}(::ICRSCoords{T}) = T
+_eltype{e,T}(::Type{FK5Coords{e,T}}) = T
+_eltype{T}(::Type{GalCoords{T}}) = T
+_eltype{T}(::Type{ICRSCoords{T}}) = T
+
 
 # Scalar coordinate conversions
 convert{T<:AbstractSkyCoords}(::Type{T}, c::T) = c
 function convert{T<:AbstractSkyCoords, S<:AbstractSkyCoords}(::Type{T}, c::S)
-    r = rotmat(T, S) * coords2cart(c)
+    r = Matrix33{_eltype(c)}(rotmat(T, S)) * coords2cart(c)
     lon, lat = cart2coords(r)
     T(lon, lat)
 end
@@ -218,7 +255,7 @@ end
 convert{T<:AbstractSkyCoords,n}(::Type{Array{T,n}}, c::Array{T,n}) = c
 function convert{T<:AbstractSkyCoords, n, S<:AbstractSkyCoords}(
     ::Type{Array{T,n}}, c::Array{S, n})
-    m = rotmat(T, S)
+    m = Matrix33{_eltype(S)}(rotmat(T, S))
     result = similar(c, T)
     for i in 1:length(c)
         r = m * coords2cart(c[i])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,13 +56,13 @@ rad2arcsec(r) = 3600.*rad2deg(r)
 fname = joinpath(datapath, "input_coords.csv")
 indata, inhdr = readcsv(fname; header=true)
 
-for (insys, T) in (("icrs", ICRSCoords), ("fk5j2000", FK5Coords{2000}),
-                   ("fk5j1975", FK5Coords{1975}), ("gal", GalCoords))
+for (insys, T) in (("icrs", ICRSCoords{Float64}), ("fk5j2000", FK5Coords{Float64,2000}),
+                   ("fk5j1975", FK5Coords{Float64,1975}), ("gal", GalCoords{Float64}))
 
     c_in = T[T(indata[i, 1], indata[i, 2]) for i=1:size(indata,1)]
 
-    for (outsys, S) in (("icrs", ICRSCoords), ("fk5j2000", FK5Coords{2000}),
-                        ("fk5j1975", FK5Coords{1975}), ("gal", GalCoords))
+    for (outsys, S) in (("icrs", ICRSCoords{Float64}), ("fk5j2000", FK5Coords{Float64,2000}),
+                        ("fk5j1975", FK5Coords{Float64,1975}), ("gal", GalCoords{Float64}))
         (outsys == insys) && continue    
         c_out = convert(Vector{S}, c_in)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,20 +56,20 @@ rad2arcsec(r) = 3600.*rad2deg(r)
 fname = joinpath(datapath, "input_coords.csv")
 indata, inhdr = readcsv(fname; header=true)
 
-for (insys, T) in (("icrs", ICRSCoords{Float64}), ("fk5j2000", FK5Coords{Float64,2000}),
-                   ("fk5j1975", FK5Coords{Float64,1975}), ("gal", GalCoords{Float64}))
+for (insys, T) in (("icrs", ICRSCoords), ("fk5j2000", FK5Coords{2000}),
+                   ("fk5j1975", FK5Coords{1975}), ("gal", GalCoords))
 
     c_in = T[T(indata[i, 1], indata[i, 2]) for i=1:size(indata,1)]
 
-    for (outsys, S) in (("icrs", ICRSCoords{Float64}), ("fk5j2000", FK5Coords{Float64,2000}),
-                        ("fk5j1975", FK5Coords{Float64,1975}), ("gal", GalCoords{Float64}))
+    for (outsys, S) in (("icrs", ICRSCoords), ("fk5j2000", FK5Coords{2000}),
+                        ("fk5j1975", FK5Coords{1975}), ("gal", GalCoords))
         (outsys == insys) && continue    
-        c_out = convert(Vector{S}, c_in)
+        c_out = [convert(S, c) for c in c_in]
 
         # Read in reference answers.
         fname = joinpath(datapath, "$(insys)_to_$(outsys).csv")
         refdata, hdr = readcsv(fname; header=true)
-        c_ref = S[S(refdata[i, 1], refdata[i, 2]) for i=1:size(refdata,1)]
+        c_ref = [S(refdata[i, 1], refdata[i, 2]) for i=1:size(refdata,1)]
 
         # compare
         sep = angsep(c_out, c_ref)


### PR DESCRIPTION
Fixes issue #3.

This mostly works, but can be probably improved.  For example, there is a large degradation of performance when performing the conversion `ICRSCoords` → `FK5Coords`.  New `julia_time.csv` on my machine is

```
n,system,time
1,galactic,1.24548113e-7
1,fk5j2000,1.67071799e-6
1,fk5j1975,1.68228079e-6
10,galactic,1.23871095e-6
10,fk5j2000,1.5125064599999998e-5
10,fk5j1975,1.4922568699999999e-5
100,galactic,1.26191814e-5
100,fk5j2000,0.00015156769
100,fk5j1975,0.000144447023
1000,galactic,0.000140467894
1000,fk5j2000,0.0014217310499999999
1000,fk5j1975,0.0014457119299999999
10000,galactic,0.0014525985299999999
10000,fk5j2000,0.0143776014
10000,fk5j1975,0.014249403099999999
100000,galactic,0.0142425167
100000,fk5j2000,0.14345174
100000,fk5j1975,0.144378613
1000000,galactic,0.145230837
1000000,fk5j2000,1.390953208
1000000,fk5j1975,1.635042197
```

But I believe that [`@generated` functions](http://docs.julialang.org/en/stable/manual/metaprogramming/#generated-functions) can help in this place.  Simply by putting `@generated` before each `rotmat` function definition the above benchmarks become:

```
n,system,time
1,galactic,1.1377778099999999e-7
1,fk5j2000,1.08493519e-7
1,fk5j1975,1.04538305e-7
10,galactic,1.15875177e-6
10,fk5j2000,1.1692879000000001e-6
10,fk5j1975,1.16140914e-6
100,galactic,1.18335556e-5
100,fk5j2000,1.1913206e-5
100,fk5j1975,1.1770765800000001e-5
1000,galactic,0.000145392446
1000,fk5j2000,0.000142600254
1000,fk5j1975,0.000142577886
10000,galactic,0.00140351991
10000,fk5j2000,0.00143261115
10000,fk5j1975,0.00144257411
100000,galactic,0.0141127885
100000,fk5j2000,0.014452782
100000,fk5j1975,0.014426619900000002
1000000,galactic,0.142936295
1000000,fk5j2000,0.147281943
1000000,fk5j1975,0.146995551
```