### PR TITLE
Static arrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+StaticArrays 0.3.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ import SkyCoords: lat, lon
 
 datapath = joinpath(dirname(@__FILE__), "data")
 
-rad2arcsec(r) = 3600.*rad2deg(r)
+rad2arcsec(r) = 3600 * rad2deg(r)
 
 # input coordinates
 fname = joinpath(datapath, "input_coords.csv")


### PR DESCRIPTION
This PR is based on top of #9, so should wait that one before merging this.  I kept them separated because are logically independent.

Multiplication of `SMatrix{3,3} × SMatrix{3,3}` should be faster than the multiplication of `Matrix33 × Matrix33`.  Instead multiplication of `SMatrix{3,3} × SVector{3}` should be more or less as fast as the multiplication `Matrix33 × Vector3`, and this operation is performed at runtime.

According to my tests, this PR should leave overall performance very close to #9, the main advantage is to drop the custom types and reduce the code to maintain.  Performance should improve compared to current master.  You may want to carry out some benchmarks before applying this.