### PR TITLE
Generate rotmat functions for FK5

### DIFF
--- a/src/SkyCoords.jl
+++ b/src/SkyCoords.jl
@@ -161,25 +161,25 @@ rotmat{T1<:ICRSCoords, T2<:GalCoords}(::Type{T1}, ::Type{T2}) = GAL_TO_ICRS
 # Define both these so that `convert(FK5Coords{e}, ...)` and
 # `convert(FK5Coords{e,T}, ...)` both work. Similar with other
 # FK5Coords rotmat methods below.
-rotmat{e1, T2<:ICRSCoords}(::Type{FK5Coords{e1}}, ::Type{T2}) =
+@generated rotmat{e1,T2<:ICRSCoords}(::Type{FK5Coords{e1}}, ::Type{T2}) =
     precess_from_j2000(e1) * ICRS_TO_FK5J2000
-rotmat{e1, T1, T2<:ICRSCoords}(::Type{FK5Coords{e1,T1}}, ::Type{T2}) =
+@generated rotmat{e1,T1,T2<:ICRSCoords}(::Type{FK5Coords{e1,T1}}, ::Type{T2}) =
     precess_from_j2000(e1) * ICRS_TO_FK5J2000
 
-rotmat{e1, T2<:GalCoords}(::Type{FK5Coords{e1}}, ::Type{T2}) =
+@generated rotmat{e1,T2<:GalCoords}(::Type{FK5Coords{e1}}, ::Type{T2}) =
     precess_from_j2000(e1) * GAL_TO_FK5J2000
-rotmat{e1, T1, T2<:GalCoords}(::Type{FK5Coords{e1,T1}}, ::Type{T2}) =
+@generated rotmat{e1,T1,T2<:GalCoords}(::Type{FK5Coords{e1,T1}}, ::Type{T2}) =
     precess_from_j2000(e1) * GAL_TO_FK5J2000
 
-rotmat{T1<:ICRSCoords, e2, T2}(::Type{T1}, ::Type{FK5Coords{e2,T2}}) =
+@generated rotmat{T1<:ICRSCoords, e2, T2}(::Type{T1}, ::Type{FK5Coords{e2, T2}}) =
     FK5J2000_TO_ICRS * precess_from_j2000(e2)'
 
-rotmat{T1<:GalCoords, e2, T2}(::Type{T1}, ::Type{FK5Coords{e2,T2}}) =
+@generated rotmat{T1<:GalCoords, e2, T2}(::Type{T1}, ::Type{FK5Coords{e2,T2}}) =
     FK5J2000_TO_GAL * precess_from_j2000(e2)'
 
-rotmat{e1, e2, T2}(::Type{FK5Coords{e1}}, ::Type{FK5Coords{e2,T2}}) =
+@generated rotmat{e1, e2, T2}(::Type{FK5Coords{e1}}, ::Type{FK5Coords{e2,T2}}) =
     precess_from_j2000(e1) * precess_from_j2000(e2)'
-rotmat{e1, T1, e2, T2}(::Type{FK5Coords{e1,T1}}, ::Type{FK5Coords{e2,T2}}) =
+@generated rotmat{e1, T1, e2, T2}(::Type{FK5Coords{e1,T1}}, ::Type{FK5Coords{e2,T2}}) =
     precess_from_j2000(e1) * precess_from_j2000(e2)'
 
 # get floating point type in coordinates


### PR DESCRIPTION
You [said](https://github.com/kbarbary/SkyCoords.jl/pull/4) that you'd like to avoid using generated functions, but if a computation depends *only* on the type of the arguments, than generated functions are *extremely* fast, because the result is cached for that type, they're just like constants.

This is the benchmark plot I get with this PR:
![bench](https://user-images.githubusercontent.com/765740/31629956-6e93adf4-b2b5-11e7-92ce-48933d6b1028.png)
Note the zero overhead for FK5 transformations with low number of datapoints :-)

For reference, this is the `julia_times.csv`:
```julia
n,system,time
1,galactic,9.394952681388012e-8
1,fk5j2000,8.89572025052192e-8
1,fk5j1975,8.89572025052192e-8
10,galactic,8.713148148148148e-7
10,fk5j2000,8.5265625e-7
10,fk5j1975,8.53e-7
100,galactic,8.259e-6
100,fk5j2000,8.330666666666666e-6
100,fk5j1975,8.354666666666666e-6
1000,galactic,0.00010347
1000,fk5j2000,0.000105309
1000,fk5j1975,0.000105519
10000,galactic,0.001064437
10000,fk5j2000,0.001082095
10000,fk5j1975,0.001080485
100000,galactic,0.010705465
100000,fk5j2000,0.010877652
100000,fk5j1975,0.010865952
1000000,galactic,0.108290905
1000000,fk5j2000,0.109964222
1000000,fk5j1975,0.109717114
```