### PR TITLE
Drop support for unmaintained Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - osx
   - linux
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.5
+julia 0.6
 StaticArrays 0.3.1
+Compat 0.41.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@
 # Tests against astropy.
 
 using SkyCoords
-using Base.Test
+
+using Compat.Test, Compat.DelimitedFiles, Compat.Printf
 
 import SkyCoords: lat, lon
 
@@ -13,7 +14,7 @@ rad2arcsec(r) = 3600 * rad2deg(r)
 
 # input coordinates
 fname = joinpath(datapath, "input_coords.csv")
-indata, inhdr = readcsv(fname; header=true)
+indata, inhdr = readdlm(fname, ','; header=true)
 
 # Float32 has a large tolerance compared to Float64 and BigFloat, but here we
 # are more interested in making sure that the infrastructure works for different
@@ -32,8 +33,8 @@ for (F, TOL) in ((Float32, 0.2), (Float64, 0.0001), (BigFloat, 0.0001))
             c_out = S[convert(S, c) for c in c_in]
 
             # Read in reference answers.
-            fname = joinpath(datapath, "$(insys)_to_$(outsys).csv")
-            refdata, hdr = readcsv(fname; header=true)
+            ref_fname = joinpath(datapath, "$(insys)_to_$(outsys).csv")
+            refdata, hdr = readdlm(ref_fname, ','; header=true)
             c_ref = S[S(refdata[i, 1], refdata[i, 2]) for i=1:size(refdata,1)]
 
             # compare
@@ -67,6 +68,9 @@ for T in (GalCoords, FK5Coords{2000})
     c6 = convert(T, c5)
     @test separation(c3, c6) ≈ separation(c6, c3) ≈ 1
 end
+
+# Constructor of FK5Coords{1950} with non-float arguments
+@test typeof(FK5Coords{1950}(1, big(2))) == FK5Coords{1950,BigFloat}
 
 println()
 println("All tests passed.")


### PR DESCRIPTION
Tests on Julia 0.7 are failing only because of missing
```julia
using DelimitedFiles, Printf
```
Should I use `Compat` to support this platform?
  